### PR TITLE
feat(ai/ianua): add openai-compatible shim forwarding to local cli ba…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ go.work.sum
 uv.toml
 .ruff_cache
 .pytest_cache
+ai/ianua/ianua

--- a/ai/ianua/README.md
+++ b/ai/ianua/README.md
@@ -1,0 +1,28 @@
+# Ianua
+
+OpenAI-compatible HTTP shim that forwards chat completions to local AI
+CLIs (claude, codex, gemini, opencode).
+
+## How to use
+
+Run the server:
+
+```bash
+go run . -port 8080
+```
+
+Point any OpenAI-compatible client at `http://localhost:8080/v1`:
+
+```bash
+curl http://localhost:8080/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model": "sonnet",
+        "messages": [{"role": "user", "content": "say hi"}],
+        "stream": true
+    }'
+```
+
+## Backends
+
+Currently only `claude` is wired. Exposed models: `claude`, `sonnet`, `opus`, `haiku`.

--- a/ai/ianua/backend.go
+++ b/ai/ianua/backend.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"strings"
+)
+
+// Backend is one CLI adapter. Implementations turn an OpenAI-style chat
+// request into a CLI invocation and emit text deltas back over a channel.
+type Backend interface {
+	Name() string
+	Models() []string
+	// Stream sends incremental text deltas on the returned channel and closes
+	// it when done. Errors surface via the error return on setup; mid-stream
+	// failures close the channel early.
+	Stream(ctx context.Context, req ChatRequest) (<-chan string, error)
+}
+
+// collapse messages into single prompt string. CLIs take one prompt;
+// multi-turn history folded with role markers.
+func collapseMessages(messages []ChatMessage) (system, prompt string) {
+	var sys, buf strings.Builder
+	for _, m := range messages {
+		switch m.Role {
+		case "system":
+			if sys.Len() > 0 {
+				sys.WriteString("\n\n")
+			}
+			sys.WriteString(m.Content)
+		case "user":
+			buf.WriteString("[USER]\n")
+			buf.WriteString(m.Content)
+			buf.WriteString("\n\n")
+		case "assistant":
+			buf.WriteString("[ASSISTANT]\n")
+			buf.WriteString(m.Content)
+			buf.WriteString("\n\n")
+		}
+	}
+	return sys.String(), buf.String()
+}

--- a/ai/ianua/claude.go
+++ b/ai/ianua/claude.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type ClaudeBackend struct{}
+
+func (ClaudeBackend) Name() string { return "claude" }
+
+func (ClaudeBackend) Models() []string {
+	return []string{"claude", "sonnet", "opus", "haiku"}
+}
+
+// claude stream-json event shape (only fields we care about).
+type claudeEvent struct {
+	Type    string `json:"type"`
+	Message struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	} `json:"message"`
+	Result string `json:"result"`
+	Error  string `json:"error"`
+}
+
+func claudeArgs(model, prompt, system string) []string {
+	args := []string{
+		"-p", strings.TrimSpace(prompt),
+		"--model", model,
+		"--output-format", "stream-json",
+		"--verbose",
+		"--no-session-persistence",
+	}
+	if system != "" {
+		args = append(args, "--system-prompt", system)
+	}
+	return args
+}
+
+// extract the concatenated text content from a single assistant event.
+func eventText(ev claudeEvent) string {
+	if ev.Type != "assistant" {
+		return ""
+	}
+	var b strings.Builder
+	for _, blk := range ev.Message.Content {
+		if blk.Type == "text" {
+			b.WriteString(blk.Text)
+		}
+	}
+	return b.String()
+}
+
+// pumpStream reads claude NDJSON from r and emits incremental text deltas on
+// out. claude emits cumulative message snapshots, so each emission is the
+// suffix beyond what we've already sent.
+func pumpStream(ctx context.Context, r io.Reader, out chan<- string) {
+	scanner := bufio.NewScanner(r)
+	// claude can emit long JSON lines (system init dump). Bump buffer.
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+
+	var emitted string
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 || line[0] != '{' {
+			continue
+		}
+		var ev claudeEvent
+		if json.Unmarshal(line, &ev) != nil {
+			continue
+		}
+		full := eventText(ev)
+		if full == "" || full == emitted {
+			continue
+		}
+		delta := full
+		if strings.HasPrefix(full, emitted) {
+			delta = full[len(emitted):]
+		}
+		select {
+		case out <- delta:
+		case <-ctx.Done():
+			return
+		}
+		emitted = full
+	}
+}
+
+func cleanupSandbox(path string) {
+	if err := os.RemoveAll(path); err != nil {
+		log.Printf("ianua: sandbox cleanup %s: %v", path, err)
+	}
+}
+
+func (c ClaudeBackend) Stream(ctx context.Context, req ChatRequest) (<-chan string, error) {
+	system, prompt := collapseMessages(req.Messages)
+
+	model := req.Model
+	if model == "" || model == "claude" {
+		model = "sonnet"
+	}
+
+	// claude inherits cwd-derived project state (CLAUDE.md, git repo,
+	// hooks) from the caller, which can trigger interactive policy prompts
+	// that block headless -p runs. Sandbox each invocation in a fresh
+	// tempdir to keep the CLI environment-clean.
+	sandbox, err := os.MkdirTemp("", "ianua-claude-")
+	if err != nil {
+		return nil, fmt.Errorf("claude sandbox dir: %w", err)
+	}
+
+	// args are passed as separate argv to exec.Command — not interpolated into
+	// a shell. Caller-controlled model/prompt/system are inert here.
+	// #nosec G204
+	cmd := exec.CommandContext(ctx, "claude", claudeArgs(model, prompt, system)...)
+	cmd.Dir = sandbox
+	cmd.Stderr = io.Discard
+	cmd.Stdin = strings.NewReader("")
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cleanupSandbox(sandbox)
+		return nil, fmt.Errorf("claude stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		cleanupSandbox(sandbox)
+		return nil, fmt.Errorf("claude start: %w", err)
+	}
+
+	out := make(chan string, 16)
+	go func() {
+		defer close(out)
+		defer cleanupSandbox(sandbox)
+		defer func() {
+			if err := cmd.Wait(); err != nil {
+				// claude often exits non-zero on context cancel; debug only.
+				log.Printf("ianua: claude exit: %v", err)
+			}
+		}()
+		pumpStream(ctx, stdout, out)
+	}()
+
+	return out, nil
+}

--- a/ai/ianua/go.mod
+++ b/ai/ianua/go.mod
@@ -1,0 +1,5 @@
+module github.com/streambinder/unciae/ai/ianua
+
+go 1.25.0
+
+toolchain go1.25.8

--- a/ai/ianua/main.go
+++ b/ai/ianua/main.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+)
+
+var backends = map[string]Backend{}
+
+func registerBackend(b Backend) {
+	for _, m := range b.Models() {
+		backends[m] = b
+	}
+}
+
+func pickBackend(model string) Backend {
+	if b, ok := backends[model]; ok {
+		return b
+	}
+	// also accept "claude:<variant>" style
+	if i := strings.Index(model, ":"); i > 0 {
+		if b, ok := backends[model[:i]]; ok {
+			return b
+		}
+	}
+	return nil
+}
+
+func handleModels(w http.ResponseWriter, _ *http.Request) {
+	list := ModelList{Object: "list"}
+	for id := range backends {
+		list.Data = append(list.Data, Model{
+			ID:      id,
+			Object:  "model",
+			Created: time.Now().Unix(),
+			OwnedBy: "ianua",
+		})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(list); err != nil {
+		log.Printf("encode models: %v", err)
+	}
+}
+
+func handleChat(w http.ResponseWriter, r *http.Request) {
+	var req ChatRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad request: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	b := pickBackend(req.Model)
+	if b == nil {
+		http.Error(w, "unknown model: "+req.Model, http.StatusNotFound)
+		return
+	}
+
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	deltas, err := b.Stream(ctx, req)
+	if err != nil {
+		http.Error(w, "backend start: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+
+	id := fmt.Sprintf("chatcmpl-%d", time.Now().UnixNano())
+	created := time.Now().Unix()
+
+	if req.Stream {
+		writeSSE(w, id, created, req.Model, deltas)
+		return
+	}
+	writeJSON(w, id, created, req.Model, deltas)
+}
+
+func writeSSE(w http.ResponseWriter, id string, created int64, model string, deltas <-chan string) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	send := func(chunk ChatChunk) error {
+		buf, err := json.Marshal(chunk)
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "data: %s\n\n", buf); err != nil {
+			return err
+		}
+		flusher.Flush()
+		return nil
+	}
+
+	// initial role chunk (OpenAI convention)
+	if err := send(ChatChunk{
+		ID: id, Object: "chat.completion.chunk", Created: created, Model: model,
+		Choices: []DeltaChoice{{Delta: ChatMessage{Role: "assistant"}}},
+	}); err != nil {
+		return
+	}
+
+	for d := range deltas {
+		if err := send(ChatChunk{
+			ID: id, Object: "chat.completion.chunk", Created: created, Model: model,
+			Choices: []DeltaChoice{{Delta: ChatMessage{Content: d}}},
+		}); err != nil {
+			return
+		}
+	}
+
+	stop := "stop"
+	if err := send(ChatChunk{
+		ID: id, Object: "chat.completion.chunk", Created: created, Model: model,
+		Choices: []DeltaChoice{{FinishReason: &stop}},
+	}); err != nil {
+		return
+	}
+	if _, err := fmt.Fprint(w, "data: [DONE]\n\n"); err != nil {
+		return
+	}
+	flusher.Flush()
+}
+
+func writeJSON(w http.ResponseWriter, id string, created int64, model string, deltas <-chan string) {
+	var full strings.Builder
+	for d := range deltas {
+		full.WriteString(d)
+	}
+	resp := ChatResponse{
+		ID: id, Object: "chat.completion", Created: created, Model: model,
+		Choices: []Choice{{
+			Index:        0,
+			Message:      ChatMessage{Role: "assistant", Content: full.String()},
+			FinishReason: "stop",
+		}},
+		Usage: Usage{},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		log.Printf("encode response: %v", err)
+	}
+}
+
+func main() {
+	port := flag.Int("port", 8080, "listen port")
+	flag.Parse()
+
+	registerBackend(ClaudeBackend{})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /v1/models", handleModels)
+	mux.HandleFunc("POST /v1/chat/completions", handleChat)
+
+	addr := fmt.Sprintf(":%d", *port)
+	log.Printf("ianua listening on %s — backends: %d models", addr, len(backends))
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	log.Fatal(srv.ListenAndServe())
+}

--- a/ai/ianua/openai.go
+++ b/ai/ianua/openai.go
@@ -1,0 +1,61 @@
+package main
+
+// OpenAI chat completions wire format.
+
+type ChatMessage struct {
+	Role    string `json:"role,omitempty"`
+	Content string `json:"content"`
+}
+
+type ChatRequest struct {
+	Model    string        `json:"model"`
+	Messages []ChatMessage `json:"messages"`
+	Stream   bool          `json:"stream,omitempty"`
+}
+
+type Usage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+type Choice struct {
+	Index        int         `json:"index"`
+	Message      ChatMessage `json:"message"`
+	FinishReason string      `json:"finish_reason"`
+}
+
+type ChatResponse struct {
+	ID      string   `json:"id"`
+	Object  string   `json:"object"`
+	Created int64    `json:"created"`
+	Model   string   `json:"model"`
+	Choices []Choice `json:"choices"`
+	Usage   Usage    `json:"usage"`
+}
+
+type DeltaChoice struct {
+	Index        int         `json:"index"`
+	Delta        ChatMessage `json:"delta"`
+	FinishReason *string     `json:"finish_reason"`
+}
+
+type ChatChunk struct {
+	ID      string        `json:"id"`
+	Object  string        `json:"object"`
+	Created int64         `json:"created"`
+	Model   string        `json:"model"`
+	Choices []DeltaChoice `json:"choices"`
+}
+
+type Model struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Created int64  `json:"created"`
+	OwnedBy string `json:"owned_by"`
+}
+
+type ModelList struct {
+	Object string  `json:"object"`
+	Data   []Model `json:"data"`
+}

--- a/go.work
+++ b/go.work
@@ -3,6 +3,7 @@ go 1.25.0
 toolchain go1.25.8
 
 use (
+	./ai/ianua
 	./audio/inflarics
 	./audio/pluffer
 )


### PR DESCRIPTION
…ckends

Bridges OpenAI-style /v1/chat/completions and /v1/models requests onto locally installed AI CLIs, letting tools that only speak the OpenAI wire format drive backends without API keys. Each request spawns the CLI in a fresh tempdir sandbox to avoid inheriting project state that would otherwise trigger interactive policy prompts. Streaming and non-streaming responses both supported. First wired backend: claude.